### PR TITLE
fix: handle GitHub Pages not configured scenario

### DIFF
--- a/.github/workflows/dashboard-deploy.yml
+++ b/.github/workflows/dashboard-deploy.yml
@@ -24,6 +24,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      pages-enabled: ${{ steps.setup-pages.outcome == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -139,11 +141,22 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        continue-on-error: true
+        id: setup-pages
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        if: steps.setup-pages.outcome == 'success'
         with:
           path: ./dashboard/_site
+          
+      - name: Pages not configured
+        if: steps.setup-pages.outcome != 'success'
+        run: |
+          echo "⚠️ GitHub Pages not configured for this repository"
+          echo "📋 Dashboard built successfully but not deployed"
+          echo "🔧 To enable Pages: Go to Settings → Pages → Set source to 'GitHub Actions'"
+          echo "📁 Dashboard files available in build artifacts"
 
   deploy:
     environment:
@@ -151,6 +164,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: needs.build.outputs.pages-enabled == 'true'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
- Add continue-on-error to Pages setup to prevent workflow failure
- Add conditional logic to skip deployment if Pages not enabled
- Provide clear instructions for enabling Pages in workflow output
- Dashboard still builds successfully, just won't deploy

🔧 Issue: HttpError Not Found when Pages not configured
✅ Solution: Graceful fallback with helpful error messages
📋 Next: Enable Pages in repository settings for deployment

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: MementoRC (https://github.com/MementoRC)

---

## 🔍 CI Pipeline Analysis

### 📁 Change Detection
| Type | Detected | Checks |
|------|----------|--------|
| 🐍 Python Code | ❌ No | Skipped |
| 🧪 Tests | ❌ No | Skipped |
| 📚 Docs | ❌ No | Skipped |
| 🔧 CI/CD | ✅ Yes | Quality gates, Security |

### ⚙️ Why Are Some Checks Skipped?
Our CI system uses **intelligent path filtering** to only run relevant checks:
- 🧪 **Testing** only runs when Python code or tests change
- ⚡ **Performance** only runs when Python code changes  
- 🌍 **Cross-platform** only runs when Python code changes
- 🔒 **Security** runs for Python or CI changes

✅ **This saves compute resources and speeds up your workflow!**

*🤖 This analysis is automatically updated on each push*